### PR TITLE
check for readpcap and interface selected simultaneously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.vscode/
-__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+__pycache__/

--- a/satori.py
+++ b/satori.py
@@ -280,8 +280,11 @@ try:
   #need to eventually do a check to make sure both readpcap and interface are not both set!
   for opt, val in opts:
     if opt in ('-r', '--read'):
+      if interface != '':
+        print('\nCannot operate in interface and readpcap mode simultaneously, please select only one.')
+        sys.exit()
       if not os.path.isfile(val):
-        print ('\nFile "%s" does not appear to exist, please verify pcap file name.' % val)
+        print('\nFile "%s" does not appear to exist, please verify pcap file name.' % val)
         sys.exit()
       else:
         proceed = True
@@ -289,6 +292,9 @@ try:
     if opt in ('-m', '--modules'):
       modules = val
     if opt in ('-i', '--interface'):
+      if readpcap != '':
+        print('\nCannot operate in interface and readpcap mode simultaneously, please select only one.')
+        sys.exit()
       interface = val
       proceed = True
     if opt in ('-l', '--log'):  #not implemented yet


### PR DESCRIPTION
Added a check in for command line arguments, when both pcap and interface mode are selected. Error message on output.

Gitignore file added too.